### PR TITLE
Make payment_secret mandatory and ASSUMED

### DIFF
--- a/09-features.md
+++ b/09-features.md
@@ -38,7 +38,7 @@ The Context column decodes as follows:
 | 8/9   | `var_onion_optin`                 | ASSUMED                                                   |          |                             |                                                                       |
 | 10/11 | `gossip_queries_ex`               | Gossip queries can include additional information         | IN       |                             | [BOLT #7][bolt07-query]                                               |
 | 12/13 | `option_static_remotekey`         | ASSUMED                                                   |          |                             |                                                                       |
-| 14/15 | `payment_secret`                  | Node supports `payment_secret` field                      | IN9      |                             | [Routing Onion Specification][bolt04]                                 |
+| 14/15 | `payment_secret`                  | ASSUMED                      | IN9      |                             | [Routing Onion Specification][bolt04]                                 |
 | 16/17 | `basic_mpp`                       | Node can receive basic multi-part payments                | IN9      | `payment_secret`            | [BOLT #4][bolt04-mpp]                                                 |
 | 18/19 | `option_support_large_channel`    | Can create large channels                                 | IN       |                             | [BOLT #2](02-peer-protocol.md#the-open_channel-message)               |
 | 22/23 | `option_anchors`                  | Anchor commitment type with zero fee HTLC transactions    | IN       |                             | [BOLT #3][bolt03-htlc-tx], [lightning-dev][ml-sighash-single-harmful] |

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -205,8 +205,8 @@ A writer:
     - MUST specify the most-preferred field first, followed by less-preferred fields, in order.
 
 A reader:
-  - MUST skip over unknown fields, OR an `f` field with unknown `version`, OR  `p`, `h`, `s` or
-  `n` fields that do NOT have `data_length`s of 52, 52, 52 or 53, respectively.
+  - MUST skip over unknown fields, OR an `f` field with unknown `version`, OR  `p`, `h` or
+  `n` fields that do NOT have `data_length`s of 52, 52 or 53, respectively.
   - if the `9` field contains unknown _odd_ bits that are non-zero:
     - MUST ignore the bit.
   - if the `9` field contains unknown _even_ bits that are non-zero:
@@ -216,8 +216,10 @@ A reader:
   description.
   - if a valid `n` field is provided:
     - MUST use the `n` field to validate the signature instead of performing signature recovery.
-  - if there is a valid `s` field:
-    - MUST use that as [`payment_secret`](04-onion-routing.md#tlv_payload-payload-format)
+  - if a valid `s` field is not provided:
+    - MUST fail the payment.
+  - otherwise:
+    - MUST use the `s` field as [`payment_secret`](04-onion-routing.md#tlv_payload-payload-format)
   - if the `c` field (`min_final_cltv_expiry_delta`) is not provided:
     - MUST use an expiry delta of at least 18 when making the payment
   - if an `m` field is provided:
@@ -783,6 +785,9 @@ Breakdown:
 
 > ### Invalid sub-millisatoshi precision.
 > lnbc2500000001p1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgq0lzc236j96a95uv0m3umg28gclm5lqxtqqwk32uuk4k6673k6n5kfvx3d2h8s295fad45fdhmusm8sjudfhlf6dcsxmfvkeywmjdkxcp99202x
+
+> ### Missing required `s` field.
+> lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqs9qrsgq7ea976txfraylvgzuxs8kgcw23ezlrszfnh8r6qtfpr6cxga50aj6txm9rxrydzd06dfeawfk6swupvz4erwnyutnjq7x39ymw6j38gp49qdkj
 
 # Authors
 


### PR DESCRIPTION
## Background
The BOLT 11 payment secret (`s` field) was previously required for writers but not for readers (as implemented in #887), likely to maintain backward compatibility with unupgraded nodes during the initial rollout period. Now that several years have passed and implementations have widely adopted this requirement, this PR updates the spec to make the payment secret field mandatory for both writer and reader, and updates the `payment_secret` feature to ASSUMED status in BOLT 9.

## Changes

1. Added requirement for readers to fail payment if the `s` field is missing
2. Remove requirement to skip 's' fields with incorrect length
3. Added a test vector demonstrating an invalid invoice that's missing the `s` field
4. Changed the `payment_secret` feature to ASSUMED in BOLT 9, since all nodes are now required to support it

## Motivation
This change improves protocol privacy by ensuring that all Lightning invoices contain a payment secret. The payment secret prevents intermediate nodes in the payment path from probing for the destination by generating their own payment onions. Since implementations like LDK have already implemented this requirement (refusing to pay invoices missing a payment secret) and it's been ~4 years since the writer-side requirement was introduced, formalizing it in the specification makes sense. At this point, all implementations now always write payment secrets, and other implementations should follow LDK's example in refusing to process invoices without them.

Making the `payment_secret` feature ASSUMED in BOLT 9 reflects the reality that this feature has become standard across the Lightning Network and should be considered a core part of the protocol rather than an optional feature.